### PR TITLE
Remove named parameters

### DIFF
--- a/source/replicate.hpp
+++ b/source/replicate.hpp
@@ -31,7 +31,7 @@ namespace tarsier {
             /// trigger loops over the members of a tuple.
             template<std::size_t Index = 0, typename ...Tuple>
             static typename std::enable_if<Index == sizeof...(Tuple), void>::type
-            trigger(std::tuple<Tuple...>&, Event& event) {}
+            trigger(std::tuple<Tuple...>&, Event&) {}
             template<std::size_t Index = 0, typename ...Tuple>
             static typename std::enable_if<Index<sizeof...(Tuple), void>::type
             trigger(std::tuple<Tuple...>& tuple, Event& event) {


### PR DESCRIPTION
Causes warnings on some compilers
